### PR TITLE
AudioKit is not stopped when the tuner is stopped

### DIFF
--- a/TuningFork/TuningFork.swift
+++ b/TuningFork/TuningFork.swift
@@ -177,6 +177,7 @@ A Tuner uses the devices microphone and interprets the frequency, pitch, etc.
   public func stop() {
     microphone.stop()
     tracker.stop()
+    AudioKit.stop()
     timer?.pause()
   }
   


### PR DESCRIPTION
If the tuner is started, stopped, and started again it will trigger a crash in the application.  AudioKit.stop() can be called manually from the client, but should be called by the library.